### PR TITLE
Playlist Caching Added. URL caching added.

### DIFF
--- a/playx/cache.py
+++ b/playx/cache.py
@@ -4,11 +4,14 @@ import os
 import threading
 import glob
 import sys
+import json
 import urllib.request
+
+from json.decoder import JSONDecodeError
 
 from playx.stringutils import (
     remove_multiple_spaces, remove_punct, compute_jaccard, remove_stopwords,
-    check_keywords
+    check_keywords, fix_title
 )
 from playx.logger import Logger
 
@@ -137,6 +140,31 @@ def search_locally(song=None):
     else:
         match = []
     return match
+
+
+def update_URL_cache(title, URL):
+    """
+    Update the URL cache saved in the mapURL.json file.
+    """
+    cache_dir = os.path.expanduser('~/.playx/songs')
+    file_path = os.path.join(cache_dir, 'mapURL.json')
+    song_path = os.path.join(cache_dir, fix_title(title))
+
+    if not os.path.exists(file_path):
+        temp = open(file_path, 'w')
+        temp.close()
+        data = {}
+    else:
+        with open(file_path, 'r') as RSTREAM:
+            try:
+                data = json.load(RSTREAM)
+            except JSONDecodeError:
+                data = {}
+
+    data.update({URL: song_path})
+
+    WSTREAM = open(file_path, 'w')
+    json.dump(data, WSTREAM)
 
 
 if __name__ == "__main__":

--- a/playx/cache.py
+++ b/playx/cache.py
@@ -142,6 +142,21 @@ def search_locally(song=None):
     return match
 
 
+def search_URL(URL):
+    """
+    Check if the URL is cached.
+    """
+    file_path = os.path.expanduser('~/.playx/songs/mapURL.json')
+    logger.debug(URL)
+    RSTREAM = open(file_path, 'r')
+    data = json.load(RSTREAM)
+    logger.info("Searching {} in the cached file".format(URL))
+    try:
+        return data[URL]
+    except KeyError:
+        return None
+
+
 def update_URL_cache(title, URL):
     """
     Update the URL cache saved in the mapURL.json file.

--- a/playx/logger.py
+++ b/playx/logger.py
@@ -1,4 +1,4 @@
-import logging
+
 from pathlib import Path
 import datetime
 import os
@@ -65,6 +65,15 @@ class Logger:
                               )
         self._console_format = '[{}]: {}'.format(self.name, message)
         self._file_format = '[{}]-[{}]: {}\n'.format(self.name, DATETIME_FORMAT, message)
+
+    def hold(self):
+        """
+        Hold the screen by using input()
+        """
+        LEVEL_NUMBER = 0
+
+        if LEVEL_NUMBER >= self.level:
+            input("Screen hold! Press any key to continue")
 
     def debug(self, message):
         """

--- a/playx/logger.py
+++ b/playx/logger.py
@@ -100,3 +100,4 @@ class Logger:
         """
         LEVEL_NUMBER = 4
         self._write(message, LEVEL_NUMBER)
+        exit()

--- a/playx/player.py
+++ b/playx/player.py
@@ -5,7 +5,7 @@ from playx.utility import (
 )
 
 from playx.cache import (
-    search_locally
+    search_locally, update_URL_cache
 )
 
 from playx.youtube import (
@@ -61,6 +61,8 @@ class URLPlayer():
         """
         if not self.no_cache:
             dw(self.title, self.stream_url)
+            # Update the cache.
+            update_URL_cache(self.title, self.URL)
         else:
             logger.info('Caching is disabled')
 
@@ -109,10 +111,14 @@ class URLPlayer():
         else:
             self._extract_songObj()
 
+        logger.debug(self.title)
+
         # Now search the song locally
         if not self.dont_cache_search:
             match = search_locally(self.title)
             if match:
+                # Update the URL cache. This is necessary for the old songs.
+                update_URL_cache(self.title, self.URL)
                 # Change the value to local path
                 self.stream_url = match[1]
             else:
@@ -288,7 +294,6 @@ class Player(URLPlayer, NamePlayer):
         elif self.datatype == "song":
             self.play_name(self.data)
         elif self.datatype == 'playlist':
-            logger.debug(len(self._iterable_list))
             for i in self._iterable_list:
                 # For different playlists the player needs to act
                 # differently

--- a/playx/player.py
+++ b/playx/player.py
@@ -245,7 +245,8 @@ class Player(URLPlayer, NamePlayer):
                                 'soundcloud',
                                 'billboard',
                                 'jiosaavn',
-                                'gaana'
+                                'gaana',
+                                'cached'
                               ]
         self._datatypes = [
                             'playlist',

--- a/playx/player.py
+++ b/playx/player.py
@@ -5,7 +5,7 @@ from playx.utility import (
 )
 
 from playx.cache import (
-    search_locally, update_URL_cache
+    search_locally, update_URL_cache, search_URL
 )
 
 from playx.youtube import (
@@ -27,6 +27,8 @@ from playx.stringutils import (
 from playx.soundcloud import (
     get_track_info
 )
+
+from os.path import basename
 
 
 # Setup logger
@@ -135,6 +137,16 @@ class URLPlayer():
         Play the song by using the URL.
         """
         self.URL = URL
+
+        # Make a search locally to see if the song is already cached.
+        if not self.dont_cache_search:
+            song_path = search_URL(self.URL)
+            if song_path is not None:
+                self.stream_url = song_path
+                self.title = basename(song_path)
+                direct_to_play(song_path, self.show_lyrics, self.title)
+                return
+
         self.URL_type = url_type(self.URL)
         if songObj is not None:
             self.songObj = songObj

--- a/playx/playlist/__init__.py
+++ b/playx/playlist/__init__.py
@@ -9,5 +9,6 @@ __all__ = [
             'soundcloud',
             'playlistbase',
             'jiosaavn',
-            'gaana'
+            'gaana',
+            'playlistcache'
             ]

--- a/playx/playlist/playlist.py
+++ b/playx/playlist/playlist.py
@@ -41,6 +41,7 @@ class Playlist:
         """
         self.URL = URL
         self.file_path = None  # Used for cached playlists
+        self.temp_type = None  # Used for cached playlists
         self.pl_start = pl_start
         self.pl_end = pl_end
         self.type = 'N/A'
@@ -122,6 +123,7 @@ class Playlist:
         playlist_cache = playlistcache.PlaylistCache(self.URL)
         if playlist_cache.is_cached():
             self.type = 'cached'
+            self.temp_type = playlist_cache.extract_playlist_type()
             self.URL = playlist_cache.file_path
 
     def is_playlist(self):
@@ -163,5 +165,7 @@ class Playlist:
         # Cache the playlist if its not already there
         if self.type != 'cached':
             playlistcache.save_data(name, self.URL, self.type, data)
+        else:
+            self.type = self.temp_type
 
         return data

--- a/playx/playlist/playlist.py
+++ b/playx/playlist/playlist.py
@@ -13,7 +13,8 @@ from playx.playlist import (
     billboard,
     soundcloud,
     jiosaavn,
-    gaana
+    gaana,
+    playlistcache
 )
 
 import re
@@ -39,6 +40,7 @@ class Playlist:
         pl_end: Playlist end index.
         """
         self.URL = URL
+        self.file_path = None  # Used for cached playlists
         self.pl_start = pl_start
         self.pl_end = pl_end
         self.type = 'N/A'
@@ -48,7 +50,8 @@ class Playlist:
                     'billboard': billboard,
                     'soundcloud': soundcloud,
                     'jiosaavn': jiosaavn,
-                    'gaana': gaana
+                    'gaana': gaana,
+                    'cached': playlistcache
                     }
 
     def _is_spotify(self):
@@ -112,6 +115,15 @@ class Playlist:
         if len(match):
             self.type = 'gaana'
 
+    def _is_cached(self):
+        """
+        Check if the playlist is cached.
+        """
+        playlist_cache = playlistcache.PlaylistCache(self.URL)
+        if playlist_cache.is_cached():
+            self.type = 'cached'
+            self.URL = playlist_cache.file_path
+
     def is_playlist(self):
         """Check if the playlist is valid."""
 
@@ -121,6 +133,7 @@ class Playlist:
         self._is_soundcloud()
         self._is_jiosaavn()
         self._is_gaana()
+        self._is_cached()
 
         if self.type != 'N/A':
             return True
@@ -146,4 +159,9 @@ class Playlist:
                                         len(data),
                                         'song' if len(data) < 2 else 'songs'
                                     ))
+        logger.debug(data[0].content())
+        # Cache the playlist if its not already there
+        if self.type != 'cached':
+            playlistcache.save_data(name, self.URL, self.type, data)
+
         return data

--- a/playx/playlist/playlistbase.py
+++ b/playx/playlist/playlistbase.py
@@ -39,6 +39,16 @@ class SongMetadataBase:
         """
         self.search_querry = remove_duplicates(self.search_querry)
 
+    def content(self):
+        """
+        Show the content of the class
+        """
+        return "{}:{}:{}".format(
+                                self.title,
+                                self.URL,
+                                self.search_querry
+                            )
+
 
 class PlaylistBase:
     """
@@ -61,17 +71,16 @@ class PlaylistBase:
             Then truncate the markers based on the size of the list.
         """
         # Update the length of the playlist
-        if not self.pl_start or self.pl_start<1:
+        if not self.pl_start or self.pl_start < 1:
             self.pl_start = 1
-        if not self.pl_end or self.pl_end <1:
+        if not self.pl_end or self.pl_end < 1:
             self.pl_end = len(self.list_content_tuple)
 
         # reset marker to make sure it's in the order given by start/end
         start = min(self.pl_start, self.pl_end)
         end = max(self.pl_start, self.pl_end)
-        step = 1 if (self.pl_start<= self.pl_end) else -1
+        step = 1 if (self.pl_start <= self.pl_end) else -1
         if self._is_valid(start, end):
             self.list_content_tuple = self.list_content_tuple[start-1 : end]
             if step == -1:
                 self.list_content_tuple = self.list_content_tuple[::-1]
-

--- a/playx/playlist/playlistcache.py
+++ b/playx/playlist/playlistcache.py
@@ -22,6 +22,7 @@ class PlaylistCache:
     -----------------------------------------
     |[Name]:[<name of the playlist>]        |
     |[URL]:[<URL of the playlist>]          |
+    |[Type]:[<PlaylistType>]                |
     |[Song]:[Song name, URL of song, querry]|
     |........                               |
     |........                               |
@@ -43,6 +44,15 @@ class PlaylistCache:
         """
         if not self.dir_path.exists():
             makedirs(self.dir_path, exist_ok=True)
+
+    def extract_playlist_type(self):
+        """
+        Extract the type of the playlist.
+        """
+        READSTREAM = open(self.file_path)
+        FILE_CONTENTS = READSTREAM.read().split('\n')
+        TYPE = FILE_CONTENTS[2][FILE_CONTENTS[2].index(':')+2:-1]
+        return TYPE
 
     def _get_data(self, path_to_file):
         """
@@ -79,6 +89,7 @@ class PlaylistCache:
         WSTREAM = open(self.dir_path.joinpath(file_name), 'w')
         WSTREAM.write('[Name]:[{}]\n'.format(name))
         WSTREAM.write('[URL]:[{}]\n'.format(url))
+        WSTREAM.write('[TYPE]:[{}\n]'.format(pltype))
 
         for song in data:
             song_details = '[SONG]:[{},{},{}]'.format(
@@ -122,7 +133,7 @@ class CachedIE(PlaylistBase):
         self.playlist_name = FILECONTENTS[0][FILECONTENTS[0].index(':')+2: -1]
         logger.debug(self.playlist_name)
 
-        for line in FILECONTENTS[2:-1]:
+        for line in FILECONTENTS[3:-1]:
             logger.debug(line)
             song_details = line[line.index(':')+2:-1].split(',')
             logger.debug(str(song_details))

--- a/playx/playlist/playlistcache.py
+++ b/playx/playlist/playlistcache.py
@@ -1,0 +1,158 @@
+"""Functions to handle the caching of playlists."""
+
+from pathlib import Path
+from os import makedirs
+
+from playx.playlist.playlistbase import (
+    PlaylistBase, SongMetadataBase
+)
+
+from playx.logger import Logger
+
+# Get the logger
+logger = Logger('PlaylistCache')
+
+
+class PlaylistCache:
+    """
+    All functions related to playlist caching are
+    defined here.
+
+    The structure of the cached playlist is following
+    -----------------------------------------
+    |[Name]:[<name of the playlist>]        |
+    |[URL]:[<URL of the playlist>]          |
+    |[Song]:[Song name, URL of song, querry]|
+    |........                               |
+    |........                               |
+    -----------------------------------------
+
+    The playlist is saved by <NameOfPlaylist-Type>.playlist
+    """
+
+    def __init__(self, entity):
+        self.entity = entity  # Entity can be either a name or an URL
+        self.dir_path = Path('~/.playx/playlist').expanduser()
+        self.file_path = None
+        self._check_dir()
+
+    def _check_dir(self):
+        """
+        Check if the dir_path is available or not.
+        If not, create the dir.
+        """
+        if not self.dir_path.exists():
+            makedirs(self.dir_path, exist_ok=True)
+
+    def _get_data(self, path_to_file):
+        """
+        Extract the name and URL from the passed file.
+        """
+        READSTREAM = open(self.dir_path.joinpath(path_to_file), 'r')
+        FILE_CONTENTS = READSTREAM.read().split('\n')
+        NAME = FILE_CONTENTS[0][FILE_CONTENTS[0].index(':')+2:-1]
+        URL = FILE_CONTENTS[1][FILE_CONTENTS[1].index(':')+2:-1]
+        return (NAME, URL)
+
+    def is_cached(self):
+        """
+        Check if the passed playlist name or URL
+        is saved in the playlist dir.
+        """
+        files = [file for file in self.dir_path.iterdir()]
+
+        for file in files:
+            name, url = self._get_data(file)
+            logger.debug("{}:{}".format(name, url))
+            logger.debug(self.entity)
+            if (self.entity == name) or (self.entity == url):
+                self.file_path = self.dir_path.joinpath(file)
+                return True
+
+        return False
+
+    def cache(self, name, url, pltype, data):
+        """
+        Save the data locally.
+        """
+        file_name = name + '-' + pltype + '.playlist'
+        WSTREAM = open(self.dir_path.joinpath(file_name), 'w')
+        WSTREAM.write('[Name]:[{}]\n'.format(name))
+        WSTREAM.write('[URL]:[{}]\n'.format(url))
+
+        for song in data:
+            song_details = '[SONG]:[{},{},{}]'.format(
+                                                    song.title,
+                                                    song.URL,
+                                                    song.search_querry
+                                                )
+            WSTREAM.write(song_details + '\n')
+
+        WSTREAM.close()
+
+
+class CachedSongs(SongMetadataBase):
+    """
+    Class to contain songs extracted from the cached
+    playlist.
+    """
+    def __init__(self, title, URL, querry):
+        super().__init__()
+        self.title = title
+        self.URL = URL
+        self.search_querry = querry
+
+
+class CachedIE(PlaylistBase):
+    """
+    Class to extract data in cached playlists.
+    """
+    def __init__(self, URL, pl_start=None, pl_end=None):
+        super().__init__(pl_start, pl_end)
+        self.URL = URL  # Here the URL is actually a local dir path
+        self.playlist_name = ''
+
+    def get_data(self):
+        """
+        Extract the data from the cached playlist.
+        """
+        READSTREAM = open(self.URL, 'r')
+        FILECONTENTS = READSTREAM.read().split('\n')
+
+        self.playlist_name = FILECONTENTS[0][FILECONTENTS[0].index(':')+2: -1]
+        logger.debug(self.playlist_name)
+
+        for line in FILECONTENTS[2:-1]:
+            logger.debug(line)
+            song_details = line[line.index(':')+2:-1].split(',')
+            logger.debug(str(song_details))
+            logger.hold()
+            logger.debug("{}:{}:{}".format(song_details[0], song_details[1], song_details[2]))
+            self.list_content_tuple.append(CachedSongs(
+                                                        song_details[0],
+                                                        song_details[1],
+                                                        song_details[2],
+                                                    ))
+        self.strip_to_start_end()
+
+
+def save_data(PlaylistName, URL, pltype, data):
+    """
+    Cache the playlist data to a local file.
+    """
+    playlist_cache = PlaylistCache(None)
+    playlist_cache.cache(PlaylistName, URL, pltype, data)
+
+
+def get_data(URL, pl_start, pl_end):
+    """Generic function. Should be called only when
+    it is checked if the URL is a cached playlist.
+
+    Returns a tuple containing the songs and name of
+    the playlist.
+    """
+    logger.info("Extracting Playlist Contents")
+    cached_playlist = CachedIE(URL, pl_start, pl_end)
+    cached_playlist.get_data()
+
+    return cached_playlist.list_content_tuple, cached_playlist.playlist_name

--- a/playx/stringutils.py
+++ b/playx/stringutils.py
@@ -91,6 +91,14 @@ def remove_duplicates(string):
     return res
 
 
+def fix_title(title):
+    title = remove_punct(title)
+    title = remove_multiple_spaces(title)
+    if not title.endswith('.mp3'):
+        title = title + '.mp3'
+    return title
+
+
 def check_keywords(tokens1, tokens2):
     """
         Check if all the tokens from tokens1

--- a/playx/utility.py
+++ b/playx/utility.py
@@ -47,9 +47,11 @@ def direct_to_play(url, show_lyrics, title):
 
     run_mpv(url, title)
 
+
 def run_mpv(stream_url, title=None):
     # print("Playing using mpv...")
     logger.info("Playing [{}]".format(title))
+    logger.debug("URL: {}".format(stream_url))
     cli = 'mpv "{}" --really-quiet'.format(stream_url)
     os.system(cli)
     """

--- a/playx/youtube.py
+++ b/playx/youtube.py
@@ -9,8 +9,7 @@ due to all those crawling shit
 from bs4 import BeautifulSoup
 import requests
 from playx.stringutils import (
-    remove_multiple_spaces,
-    remove_punct,
+    fix_title,
     is_song_url
 )
 
@@ -140,10 +139,8 @@ def grab_link(value):
 
 def dw(title, url):
     # Start downloading
-    title = remove_punct(title)
-    title = remove_multiple_spaces(title)
-    title = title + '.mp3'
-    Cache.dw(url, title) 
+    title = fix_title(title)
+    Cache.dw(url, title)
 
 
 def main():

--- a/playx/youtube.py
+++ b/playx/youtube.py
@@ -53,8 +53,17 @@ def get_youtube_streams(url):
     PS: I don't know how youtube-dl does the magic
     """
     logger.debug("Extracting streamable links")
+    logger.debug("{}".format(url))
     cli = "youtube-dl -g {}".format(url)
     output, error = exe(cli)
+    logger.debug("{}".format(type(error)))
+
+    if error != '':
+        logger.critical("'{}' Error passed by youtube-dl. Please check if the latest version of youtube-dl is installed. You can report the error on https://yt-dl.org/bug.".format(error))
+
+    logger.debug("O/P: {}".format(output))
+    logger.debug("ERROR: {}".format(error))
+
     stream_urls = output.split("\n")
     url = {}
     try:
@@ -121,6 +130,7 @@ def search_youtube(query):
 def grab_link(value):
     """Return the audio link of the song."""
     stream = get_youtube_streams(value)
+    logger.debug(stream)
     if stream['audio'] is None: return None
     value = stream['audio']
     # if not no_cache:


### PR DESCRIPTION
Playlist passed from now on will be added to the ```~/.playx/playlist``` directory.

The name of the playlist is ```<Name extracted>-<Type of playlist>.playlist```
The type is added because an user might play two different playlists from two different sources like Spotify and Youtube.
For Eg: A playlist named ```Indie``` extracted from ```Youtube``` is saved as ```Indie-youtube.playlist```

The playlist structure is following.
```
    --------------------------------------------------------
    |[Name]:[<name of the playlist>]                
    |[URL]:[<URL of the playlist>]                    
    |[Song]:[Song name, URL of song, querry]
    |........                                                          
    |........                                                          
    --------------------------------------------------------
```
From now the argument passed, if it is not an URL but name, will be checked if it is in present in playlist dir and then passed on to be searched as song.

For eg:
```sh
playx Indie
```
will make playx check if a playlist with name ```Indie``` is present in the cache and then only if it returns False then it'll be searched in Youtube.

It supports both URL and name of playlist.
For eg:
```Indie``` has URL ```https://www.youtube.com/playlist\?list\=PLde1MXLBkacaSPq0IlrT2zK-qoPqBsRh9```
So 
```sh
playx https://www.youtube.com/playlist\?list\=PLde1MXLBkacaSPq0IlrT2zK-qoPqBsRh9
```
and 
```sh
playx Indie
```
will both end up playing the playlist ```Indie``` from the cache.