### PR TITLE
Added option to sync playlists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ python setup.py install
 For now, the application is in development phase.  
 
 ```
-usage: playx [-h] [-p] [-n] [-auto] [-d] [-l] [--pl-start PL_START]
-             [--pl-end PL_END]
+usage: playx [-h] [-p] [-n] [-auto] [-d] [-r] [--sync-playlist SYNC_PLAYLIST]
+             [-l] [--pl-start PL_START] [--pl-end PL_END]
              [song [song ...]]
 
 playx - Search and play any song that comes to your mind. If you have any
@@ -101,11 +101,16 @@ optional arguments:
   -auto, --auto         Auto generate playlist
   -d, --dont-cache-search
                         Don't search the song in the cache.
+  -r, --no-related      Disable playing related songs extracted from YouTube
+  --sync-playlist SYNC_PLAYLIST
+                        Sync the playlists. Pass the name as arguement. If all
+                        the playlists are to be synced, just pass [All].
   -l, --lyrics          Show lyircs of the song.
   --pl-start PL_START   Start position in case a playlist is passed. If passed
                         without a playlist it has no effect.
   --pl-end PL_END       End position in case a playlist is passed. If passed
                         without a playlist it has no effect.
+
 ```
 
 ------------
@@ -185,10 +190,14 @@ Structure is like:
 .playx
     |- songs/
     |- logs/
+    |- playlist/
+    |- playxlist/
 ```
 
 *songs*: This stores all the songs downloaded by `playx`  
 *logs*: This stores the log for user activities of songs that are searched and played with creation date. This will be used for recommendation of songs in future version
+*playlist*: This stores all the cached playlists files.
+*playxlist*: Stores all the playxlist files.
 
 ------------
 

--- a/playx/main.py
+++ b/playx/main.py
@@ -69,6 +69,11 @@ def parse():
                         action='store_true',
                         help="Disable playing related songs extracted\
                             from YouTube")
+    parser.add_argument('--sync-playlist',
+                        default=None, type=str,
+                        help="Sync the playlists. Pass the name as\
+                        arguement. If all the playlists are to be \
+                        synced, just pass [All].")
     parser.add_argument('-l', '--lyrics',
                         action='store_true',
                         help="Show lyircs of the song.")
@@ -148,6 +153,13 @@ def main():
     if args.auto:
         ap = CountBasedAutoPlaylist('~/.playx/logs/log.cat')
         song = ap.generate()
+
+    # Check if sync-playlists is passed
+    if args.sync_playlist is not None:
+        pl = Playlist(None, None, None)
+        pl.sync_playlist(args.sync_playlist)
+        exit(0)
+
     # Put a check to see if the passed arg is a list
     playx_list = Playxlist(song, args.pl_start, args.pl_end)
     if not playx_list.is_playx_list():

--- a/playx/playlist/playlist.py
+++ b/playx/playlist/playlist.py
@@ -126,6 +126,46 @@ class Playlist:
             self.temp_type = playlist_cache.extract_playlist_type()
             self.URL = playlist_cache.file_path
 
+    def _get_data(self):
+        """
+        Internal function to call get_data of type and get the
+        data and name of the playlist.
+        """
+        data, name = self.dict[self.type].get_data(
+                                                self.URL,
+                                                self.pl_start,
+                                                self.pl_end
+                                                )
+        return data, name
+
+    def sync_playlist(self, value):
+        """
+        Sync the playlists saved in the playlists dir.
+        """
+        playlists = playlistcache.list_all()
+
+        if value.lower() == 'all':
+            for playlist in playlists:
+                self.type = playlist[2]
+                self.URL = playlist[1]
+                logger.info("Syncing {} with {}".format(playlist[0], self.type))
+                data, name = self._get_data()
+                playlistcache.save_data(name, self.URL, self.type, data)
+        else:
+            for playlist in playlists:
+                logger.debug('{}:{}'.format(playlist[0], value))
+                req_pl = playlist if playlist[0] == value else None
+                if req_pl is not None:
+                    logger.debug(req_pl[1])
+                    self.type = req_pl[2]
+                    self.URL = req_pl[1]
+                    logger.info("Syncing {} with {}".format(req_pl[0], self.type))
+                    data, name = self._get_data()
+                    playlistcache.save_data(name, self.URL, self.type, data)
+                    return
+
+            logger.error('{}: Not found in cached playlists'.format(value))
+
     def is_playlist(self):
         """Check if the playlist is valid."""
 
@@ -151,11 +191,7 @@ class Playlist:
             return []
 
         logger.info("{} Playlist passed.".format(self.type))
-        data, name = self.dict[self.type].get_data(
-                                                self.URL,
-                                                self.pl_start,
-                                                self.pl_end
-                                                )
+        data, name = self._get_data()
         logger.info("{}: {} {}".format(
                                         name,
                                         len(data),

--- a/playx/playlist/playlistcache.py
+++ b/playx/playlist/playlistcache.py
@@ -155,6 +155,25 @@ def save_data(PlaylistName, URL, pltype, data):
     playlist_cache.cache(PlaylistName, URL, pltype, data)
 
 
+def list_all():
+    """
+    Return all the playlist names with playlist URL's
+    """
+    dir_path = Path('~/.playx/playlist').expanduser()
+    files = [file for file in dir_path.iterdir()]
+    list_playlist = []
+
+    for file in files:
+        READSTREAM = open(file)
+        FILECONTENTS = READSTREAM.read().split('\n')
+        playlist_name = FILECONTENTS[0][FILECONTENTS[0].index(':')+2: -1]
+        URL = FILECONTENTS[1][FILECONTENTS[1].index(':')+2: -1]
+        TYPE = FILECONTENTS[2][FILECONTENTS[2].index(':')+2: -1]
+        list_playlist.append([playlist_name, URL, TYPE])
+
+    return list_playlist
+
+
 def get_data(URL, pl_start, pl_end):
     """Generic function. Should be called only when
     it is checked if the URL is a cached playlist.


### PR DESCRIPTION
Since we have started caching playlists, many of the times it happens that the playlists will be updated on the source, in order to keep the cached ones up to date with the source, this option can be used by the user.

We can add the playlist to auto sync each time the playlist is called or something like that but that would be completely against the idea of caching playlist. We are caching so that the playlists can be used when there is no internet connection.

@NISH1001 Do suggest changes if you feel there should be any.