### PR TITLE
bug: fixed fetching of deleted videos in youtube playlists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,7 @@ python setup.py install
 
 ## Features
 
-<div align="center">
-<h4>
-Play Songs &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play YouTube URL&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play YouTube Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Billboard Charts&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Spotify Playlists&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Soundcloud Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play JioSaavn Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Gaana Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Local Playilst &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Cache Support &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Auto generate Playlist &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Play Related songs fetched from YouTube
-</h4>
-</div>
-
-<!-- - play by query
+- play by query
 - play by youtube url
 - play a youtube playlist
 - play a billboard chart
@@ -80,7 +74,7 @@ Play Songs &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play YouTube URL&nbsp;&nbsp;&nbs
 - cache support
 - CLI using `mpv`
 - auto generate playlist
------------- -->
+------------
 
 ## Usage
 For now, the application is in development phase.  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 </div>
 
 <div align="center">
-[Philosophy][#philosophy]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Requirements](#requirements)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Installation](#installation)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Features][#features]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Usage][#usage]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Example][#example]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Contribution][#contribution]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[TO-DO][#to-do]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Acknowledgement][#acknowledgement]
+<h3>
+<a href="#philosophy">Philosophy</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#requirements">Requirements</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#installation">Installation</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#features">Features</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#usage">Usage</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#example">Example</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#contributions">Contribution</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#to-do">To-DO</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#acknowledgements">Acknowledgements</a>
+</h3>
 </div>
 
 # playx in action

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ python setup.py install
 ## Features
 
 <div align="center">
-<h3>
+<h4>
 Play Songs &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play YouTube URL&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play YouTube Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Billboard Charts&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Spotify Playlists&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Soundcloud Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play JioSaavn Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Gaana Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Local Playilst &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Cache Support &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Auto generate Playlist &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Play Related songs fetched from YouTube
-</h3>
+</h4>
 </div>
 
 <!-- - play by query

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 <h1 align=center>
-<img src="logo/1024 bg.svg" width=100%>
+<img src="logo/1024 bg.svg" width=80%>
 </h1>
 
-## Search and play any song from terminal.
+<div align="center">
+<h1>Search and play any song from terminal.</h1>
+</div>
+
+<div align="center">
+[Philosophy][#philosophy]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Requirements](#requirements)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Installation](#installation)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Features][#features]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Usage][#usage]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Example][#example]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Contribution][#contribution]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[TO-DO][#to-do]&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Acknowledgement][#acknowledgement]
+</div>
 
 # playx in action
 
@@ -25,6 +31,7 @@
 9. [Acknowledgements](#acknowledgements)
 
 # Philosophy
+
 Play any songs that come in your mind.
 > Hoping to make it an awesome music assistant
 ---------

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ python setup.py install
 
 ## Features
 
-- play by query
+<div align="center">
+<h3>
+Play Songs &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play YouTube URL&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play YouTube Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Billboard Charts&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Spotify Playlists&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Soundcloud Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play JioSaavn Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Gaana Playlist&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Play Local Playilst &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Cache Support &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Auto generate Playlist &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp; Play Related songs fetched from YouTube
+</h3>
+</div>
+
+<!-- - play by query
 - play by youtube url
 - play a youtube playlist
 - play a billboard chart
@@ -74,7 +80,7 @@ python setup.py install
 - cache support
 - CLI using `mpv`
 - auto generate playlist
-------------
+------------ -->
 
 ## Usage
 For now, the application is in development phase.  

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 </div>
 
 <div align="center">
-<h3>
+<h4>
 <a href="#philosophy">Philosophy</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#requirements">Requirements</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#installation">Installation</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#features">Features</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#usage">Usage</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#example">Example</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#contributions">Contribution</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#to-do">To-DO</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="#acknowledgements">Acknowledgements</a>
-</h3>
+</h4>
 </div>
 
 # playx in action

--- a/README.md
+++ b/README.md
@@ -19,19 +19,6 @@
 </a>
 </p>
 
-
-# playx  
-
-1. [Philosophy](#philosophy)
-2. [Requirements](#requirements)
-3. [Installation](#installation)
-4. [Features](#features)
-5. [Usage](#usage)
-6. [Example](#example)
-7. [Contribution](#contributions)
-8. [TO-DO](#to-do)
-9. [Acknowledgements](#acknowledgements)
-
 # Philosophy
 
 Play any songs that come in your mind.

--- a/playx/playlist/youtube.py
+++ b/playx/playlist/youtube.py
@@ -5,8 +5,6 @@ defined.
 import requests
 from bs4 import BeautifulSoup
 import re
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 
 from playx.playlist.playlistbase import (
     PlaylistBase, SongMetadataBase

--- a/playx/playlist/youtube.py
+++ b/playx/playlist/youtube.py
@@ -102,6 +102,12 @@ class YoutubePlaylist(PlaylistBase):
             title = title.strip()
             if not title:
                 continue
+            # Check if the video is deleted. Some videos in playlist turn out
+            # to be deleted videos. We can put a check for that by checking
+            # if the title is [Deleted video]
+            if title.lower()[1:-1] == 'deleted video':
+                logger.debug(title.lower()[1:-1])
+                continue
             # Get video url using simple algorithm. This 3 index search is done
             # just to make sure when youtube playlist url has these query
             # params in shuffled order.


### PR DESCRIPTION
Fixed #76 

We could've taken the hardway of putting a different check while each video page is scraped. But I figured we can do that by just checking the title of the video.

Just delete the cached playlist in ~/.playx/playlist and fetch the playlist, it should be fixed.
Or you can also --sync-playlist.