### PR TITLE
Fixed playlist extension bug

### DIFF
--- a/playx/main.py
+++ b/playx/main.py
@@ -177,7 +177,7 @@ def main():
     # Check if sync-playlists is passed
     if args.sync_pl is not None:
         pl = Playlist(None, None, None)
-        pl.sync_playlist(args.sync_playlist)
+        pl.sync_playlist(args.sync_pl)
         exit(0)
 
     # Put a check to see if the passed arg is a list

--- a/playx/playlist/playlist.py
+++ b/playx/playlist/playlist.py
@@ -35,7 +35,7 @@ __github__ = github.com/deepjyoti30
 class Playlist:
     """Class for every kind of playlist supported."""
 
-    def __init__(self, URL, pl_start, pl_end, is_shuffle):
+    def __init__(self, URL, pl_start, pl_end, is_shuffle=False):
         """
         URL: Passed URL
         pl_start: Playlist start index.

--- a/playx/playlist/playlistcache.py
+++ b/playx/playlist/playlistcache.py
@@ -131,6 +131,7 @@ class PlaylistCache2:
         self.entity = entity  # Entity can be either a name or an URL
         self.dir_path = Path('~/.playx/playlist').expanduser()
         self.file_path = None
+        self._file_ext = "playlist"
         self._check_dir()
 
     def _check_dir(self):
@@ -158,7 +159,7 @@ class PlaylistCache2:
                 'search_query': song.search_query
             }
             res['data'].append(s)
-        file_name = name + '-' + pltype + '.json'
+        file_name = name + '-' + pltype + '.{}'.format(self._file_ext)
         with open(self.dir_path.joinpath(file_name), 'w') as f:
             json.dump(res, f, indent=4)
 
@@ -183,7 +184,7 @@ class PlaylistCache2:
         Check if the passed playlist name or URL
         is saved in the playlist dir.
         """
-        for fname in self.dir_path.glob("*.json"):
+        for fname in self.dir_path.glob("*.{}".format(self._file_ext)):
             name, url = self._get_data(fname)
             if (self.entity.lower() == name.lower()) or (self.entity == url):
                 self.file_path = self.dir_path.joinpath(fname)
@@ -272,7 +273,7 @@ def list_all():
     Return all the playlist names with playlist URL's
     """
     dir_path = Path('~/.playx/playlist').expanduser()
-    files = glob.glob(os.path.join(dir_path, '*.json'))
+    files = glob.glob(os.path.join(dir_path, '*.playlist'))
     # files = [file for file in dir_path.iterdir()]
     list_playlist = []
 

--- a/playx/youtube.py
+++ b/playx/youtube.py
@@ -8,6 +8,7 @@ due to all those crawling shit
 
 from bs4 import BeautifulSoup
 import requests
+import youtube_dl
 from playx.stringutils import (
     fix_title,
     is_song_url
@@ -44,6 +45,21 @@ class YoutubeMetadata:
         """Be informative."""
         logger.info("Title: {}".format(self.title))
         logger.info("Duration: {}".format(self.duration))
+
+
+def get_audio_URL(link):
+    """Return true if the song is downloaded else false."""
+    ydl_opts = {}
+    ydl_opts['quiet'] = True
+    ydl_opts['nocheckcertificate'] = True
+
+    ydl = youtube_dl.YoutubeDL(ydl_opts)
+    info = ydl.extract_info(link, download=False)
+    try:
+        audio_url = info['formats'][1]['url']
+        return audio_url
+    except Exception as e:
+        logger.critical("Could not extract the audio URL: {}".format(e))
 
 
 def get_youtube_streams(url):
@@ -129,13 +145,11 @@ def search_youtube(query, disable_kw=False):
 
 def grab_link(value):
     """Return the audio link of the song."""
-    stream = get_youtube_streams(value)
+    stream = get_audio_URL(value)
     logger.debug(stream)
-    if stream['audio'] is None: return None
-    value = stream['audio']
     # if not no_cache:
     #    Cache.dw(value, title)
-    return value
+    return stream
 
 
 def dw(title, s_url, url=None):


### PR DESCRIPTION
I have made the changes required to save the cached playlists as ```playlist``` files but are actually JSON.

Also, I had earlier changed the extraction from using ```commands``` to using the ```youtube_dl``` API.

Feel free to undo that if you want but till now evertything is working fine and the latter seems to better rather than making external calls to binaries.

Also, keep in mind, you will have to remove all the existing ```.playlist``` files or you will face issues.