### PR TITLE
Fixed a bug related to playing related songs from YT

### DIFF
--- a/playx/player.py
+++ b/playx/player.py
@@ -190,6 +190,8 @@ class NamePlayer():
         Search youtube and get its data.
         """
         data = search(self.name, self.disable_kw)
+        logger.debug("{}".format(data))
+        logger.hold()
         self.title = data.title
         self.URL = data.url
         self.stream_url = grab_link(data.url)

--- a/playx/playlist/playlistbase.py
+++ b/playx/playlist/playlistbase.py
@@ -14,7 +14,12 @@ class SongMetadataBase:
     Base class to store song metadata.
     """
 
-    def __init__(self, title, url, query):
+    def __init__(  
+            self,
+            title=None,
+            url=None,
+            query=None
+            ):
         self.title = title
         self.search_query = query
         self.URL = url

--- a/playx/playlist/playlistcache.py
+++ b/playx/playlist/playlistcache.py
@@ -211,14 +211,14 @@ class CachedIE(PlaylistBase):
         READSTREAM = open(self.URL, "r")
         FILECONTENTS = READSTREAM.read().split("\n")
 
-        self.playlist_name = FILECONTENTS[0][FILECONTENTS[0].index(":") + 2 : -1]
-        self.actual_URL = FILECONTENTS[1][FILECONTENTS[1].index(":") + 2 : -1]
-        self.type = FILECONTENTS[2][FILECONTENTS[2].index(":") + 2 : -1]
+        self.playlist_name = FILECONTENTS[0][FILECONTENTS[0].index(":") + 2: -1]
+        self.actual_URL = FILECONTENTS[1][FILECONTENTS[1].index(":") + 2: -1]
+        self.type = FILECONTENTS[2][FILECONTENTS[2].index(":") + 2: -1]
 
         for line in FILECONTENTS[3:-1]:
             logger.debug(line)
             logger.hold()
-            song_details = line[line.index(":") + 2 : -1].split(",")
+            song_details = line[line.index(":") + 2: -1].split(",")
             logger.debug(str(song_details))
             logger.debug(
                 "{}:{}:{}".format(song_details[0], song_details[1], song_details[2])

--- a/playx/playlist/ytrelated.py
+++ b/playx/playlist/ytrelated.py
@@ -28,7 +28,7 @@ class YoutubeMetadata(SongMetadataBase):
         """
         Create a search querry.
         """
-        self.search_querry = self.title
+        self.search_query = self.title
 
 
 class YoutubeRelatedIE(PlaylistBase):

--- a/playx/utility.py
+++ b/playx/utility.py
@@ -12,21 +12,6 @@ import threading
 logger = Logger('utility')
 
 
-class MPVThread(threading.Thread):
-
-    def __init__(self, URL, title=None):
-        threading.Thread.__init__(self)
-        self.songURL = URL
-        self.title = title
-
-    def run(self):
-        logger.info("Playing [{}]".format(self.title))
-        #player = MPV(ytdl=True)
-        #player.play(self.songURL)
-        #player.wait_for_playback()
-        pass
-
-
 def exe(command):
     """Execute the command externally."""
     command = command.strip()
@@ -54,18 +39,15 @@ def run_mpv(stream_url, title=None):
         title = ''.join(title.split('.')[:-1])
 
     logger.info("Playing [{}]".format(title))
-    #cli = 'mpv "{}" --really-quiet --no-video --audio-display=no'.format(stream_url)
     cli = ['mpv', stream_url, '--really-quiet', "-no-video", "--audio-display=no"]
     subprocess.Popen(cli).wait()
-    #mpv_thread = MPVThread(stream_url, title)
-    #mpv_thread.start()
-    # mpv_thread.join()
 
 
 def run_mpv_dir(directory):
     logger.info("Playing using mpv from directory :: {}".format(directory))
     cli = 'mpv "{}"'.format(directory)
     os.system(cli)
+
 
 if __name__ == '__main__':
     url = "https://r7---sn-bvvbax-3uhl.googlevideo.com/videoplayback?ip=110.44.120.206&ei=qsFSW7DmE6jMoQP3ppSICg&sparams=clen%2Cdur%2Cei%2Cgir%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Ckeepalive%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cnh%2Cpl%2Crequiressl%2Csource%2Cexpire&id=o-ANRsypPRJvgkydFW-5_ZV_zCT8JsLhV5Unh1mGiXB0WR&keepalive=yes&clen=3253260&requiressl=yes&gir=yes&nh=EAQ%2C&initcwndbps=427500&pl=23&dur=208.881&source=youtube&lmt=1468126594841376&ipbits=0&itag=251&fvip=1&mime=audio%2Fwebm&key=yt6&expire=1532171786&mm=31%2C26&mn=sn-bvvbax-3uhl%2Csn-i3beln7s&c=WEB&ms=au%2Conr&mt=1532150082&mv=m&signature=8D3E161749FBB351BACDC6AB97DF578C330E5A7F.85CA648C3E09F32DE7F882023747D84D8D288C1A&ratebypass=yes"

--- a/playx/utility.py
+++ b/playx/utility.py
@@ -6,7 +6,6 @@ import subprocess
 from shutil import move
 from playx.lyrics import search_lyricswikia
 from playx.logger import Logger
-import threading
 
 # Setup logger
 logger = Logger('utility')

--- a/playx/youtube.py
+++ b/playx/youtube.py
@@ -108,6 +108,8 @@ def add_better_search_kw(query):
     """
     Add some keywords to the search querry to get better results.
     """
+    logger.debug("{}".format(query))
+    logger.hold()
     if not is_song_url(query):
         for kw in better_search_kw:
             query += kw


### PR DESCRIPTION
Earlier while playing related songs, ```playx``` was crashing. 

I looked into the error and as it turns out that the bug was being caused because a variable name was typed wrong

i:e

```querry``` instead of ```query```.

Fixed the issue, it's working all right now. Also removed some unnecessary code related to using threads to call the player.