### PR TITLE
update: Fixed a bug that was occurring due to no search results.

### DIFF
--- a/playx/player.py
+++ b/playx/player.py
@@ -177,7 +177,7 @@ class NamePlayer():
                 disable_kw=False
                 ):
         self.name = name
-        self.URL = ''
+        self.URL = None
         self.dont_cache_search = dont_cache_search
         self.no_cache = no_cache
         self.show_lyrics = show_lyrics
@@ -190,11 +190,17 @@ class NamePlayer():
         Search youtube and get its data.
         """
         data = search(self.name, self.disable_kw)
-        logger.debug("{}".format(data))
-        logger.hold()
+
+        # Handle if the data returned is None
+        # That probably means the song wasn't found on YT
+        # and we need to skip playing that song.
+        if data is None:
+            return False
+
         self.title = data.title
         self.URL = data.url
         self.stream_url = grab_link(data.url)
+        return True
 
     def _stream_from_name(self):
         """Start streaming the song.
@@ -209,7 +215,9 @@ class NamePlayer():
                 self.title = match[0]
                 self.stream_url = match[1]
             else:
-                self._get_youtube_data_name()
+                if not self._get_youtube_data_name():
+                    return
+
                 local_path = search_URL(self.URL)
 
                 # Try to check if the URL is mapped locally.


### PR DESCRIPTION
When we play related songs, each song is fetched by the name of the song and then each of them are passed to the ```NamePlayer``` that processes the name and returns a streamable URL.

However, when we search for the son YouTube, due to some reason, sometimes the results are 0, in which case the ```search``` function in ```songfinder.py``` returns ```None```.

We were not handling this case earlier, which resulted in an error because we were trying to access the ```title``` attr of a ```NoneType```.

Fixed the above issue and it should all be fine now.