### PR TITLE
Fixed issue with spotify parser and gaana,jiosaavn parsers as well.

### DIFF
--- a/playx/playlist/gaana.py
+++ b/playx/playlist/gaana.py
@@ -34,7 +34,7 @@ class SongMetadata(SongMetadataBase):
         self.artist_seokey = ""
         self.artist_tuple = artist_tuple
         self._update_artist()
-        self._create_search_querry()
+        self._create_search_query()
         self._remove_duplicates()
         self._remove_stopletters()
 
@@ -42,7 +42,7 @@ class SongMetadata(SongMetadataBase):
         """
         Remove letters like - and numbers from the searchquery
         """
-        self.search_querry = re.sub(r"-|[0-9]|&amp", " ", self.search_querry)
+        self.search_query = re.sub(r"-|[0-9]|&amp", " ", self.search_querry)
 
     def _update_artist(self):
         """
@@ -52,11 +52,11 @@ class SongMetadata(SongMetadataBase):
         for artist in self.artist_tuple:
             self.artist_seokey += " " + artist["seokey"]
 
-    def _create_search_querry(self):
+    def _create_search_query(self):
         """
         Update the search querry of the base class.
         """
-        self.search_querry = self.track_seokey + "" + self.artist_seokey
+        self.search_query = self.track_seokey + "" + self.artist_seokey
         self._remove_stopletters()
 
 

--- a/playx/playlist/jiosaavn.py
+++ b/playx/playlist/jiosaavn.py
@@ -18,14 +18,14 @@ class SongMetadata(SongMetadataBase):
         super().__init__()
         self.title = title
         self.subtitle = subtitle
-        self._create_search_querry()
+        self._create_search_query()
         self._remove_duplicates()
 
-    def _create_search_querry(self):
+    def _create_search_query(self):
         """
         Create a search querry.
         """
-        self.search_querry = self.title + " " + self.subtitle
+        self.search_query = self.title + " " + self.subtitle
 
 
 class JioSaavnIE(PlaylistBase):

--- a/playx/playlist/soundcloud.py
+++ b/playx/playlist/soundcloud.py
@@ -18,11 +18,11 @@ class SoundCloudTrack(SongMetadataBase):
         self.download_url = download_url
         self.URL = URL
 
-    def _create_search_querry(self):
+    def _create_search_query(self):
         """
-        Create a search querry.
+        Create a search query.
         """
-        self.search_querry = self.URL
+        self.search_query = self.URL
 
 
 class SoundCloudPlaylistExtractor(PlaylistBase):

--- a/playx/playlist/spotify.py
+++ b/playx/playlist/spotify.py
@@ -18,14 +18,14 @@ class SpotifySong(SongMetadataBase):
         self.title = title
         self.artist = artist
         self.album = album
-        self._create_search_querry()
+        self._create_search_query()
         self._remove_duplicates()
 
-    def _create_search_querry(self):
+    def _create_search_query(self):
         """
         Create a search querry.
         """
-        self.search_querry = self.title + " " + self.artist
+        self.search_query = self.title + " " + self.artist
 
 
 class SpotifyIE(PlaylistBase):


### PR DESCRIPTION
Fix #118 .

The issue was being caused because most of the parsers have the variable ```search_querry``` but the PlaylistBase is looking for ```search_query```, thus this issue was occuring.

Was happening on the Billboard parser as well and  as it turns out on Spotify too. I went ahead and fixed it on all the other parser code.

PS: That spelling mistake was made by me but later the playlist base's word was changed to ```query``` but the parsers were not and so the issue  was hardly ever noticed.