### PR TITLE
Fix issue of deprecated youtube search log

### DIFF
--- a/playx/playlist/ytrelated.py
+++ b/playx/playlist/ytrelated.py
@@ -5,6 +5,7 @@ import re
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import TimeoutException
 from pathlib import Path
 import json
 
@@ -99,9 +100,14 @@ class YoutubeRelatedIE(PlaylistBase):
         someting similar.
         """
         logger.info("Using YTMusic Method")
+        logger.debug(self.url)
         driver = self._get_driver()
         driver.get(self.url)
-        WebDriverWait(driver, 10).until(lambda driver: driver.current_url != self.url)
+
+        try:
+            WebDriverWait(driver, 10).until(lambda driver: driver.current_url != self.url)
+        except TimeoutException:
+            raise DownloadError("Timeout exception occurred")
 
         # The URL should now be updated
         updated_url = driver.current_url

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     entry_points={"console_scripts": ["playx = playx.main:main"]},
     version=__version__,
     license="MIT",
-    install_requires=["youtube_dl", "requests", "beautifulsoup4", "selenium", "lxml",],
+    install_requires=["youtube_dl", "requests", "beautifulsoup4", "selenium", "lxml", "youtube_search"],
 )


### PR DESCRIPTION
@NISH1001 As the issue #123 suggests something was broken and I figured it has to be the YouTube search since `playx` scraps the page and YouTube (being Youtube) keeps changing their page pretty often. As it turned out it was due to changes to the YouTube page that was causing the issue. I fixed the code by moving to a module called [youtube-search](https://pypi.org/project/youtube-search/).

This module is dependable, I have been using it for like 3 months now on `ytmdl` and users have had no issues. 

After fixing this bug, ran into another issue that was occuring with getting the related songs from YouTubeMusic. I am yet to figure out how to fix it, however I handled the exception and made `playx` use the fallback (Youtube) method for related songs which is working all right.